### PR TITLE
Encoder tidy

### DIFF
--- a/CONFIG.example
+++ b/CONFIG.example
@@ -11,19 +11,16 @@
 # ZPKG_DIR = $(TOP)
 
 # Definitions needed for FPGA build
-export ISE = /dls_sw/FPGA/Xilinx/14.7/ISE_DS/settings64.sh
-export LM_LICENSE_FILE = 2100@diamcslicserv01.dc.diamond.ac.uk
+export ISE = /opt/Xilinx/14.7/ISE_DS/settings64.sh
+export LM_LICENSE_FILE =
 
 # Path to root filesystem
-PANDA_ROOTFS = /home/mga83/targetOS/PandABlocks-rootfs
+PANDA_ROOTFS = /repos/PandABlocks-rootfs
 # MAKE_ZPKG = $(PANDA_ROOTFS)/make-zpkg
 
 # Python interpreter for running scripts
 #
-# PYTHON = python2
-
-# Sphinx build for documentation.
-# SPHINX_BUILD = sphinx-build
+# PYTHON = python3
 
 # List of default targets to build when running make
 # DEFAULT_TARGETS = zpkg

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ PANDA_ROOTFS = $(error Define PANDA_ROOTFS in CONFIG file)
 ISE = $(error Define ISE in CONFIG file)
 
 # Build defaults that can be overwritten by the CONFIG file if required
-PYTHON = python
-SPHINX_BUILD = sphinx-build
+PYTHON = python3
 MAKE_ZPKG = $(PANDA_ROOTFS)/make-zpkg
 MAKE_GITHUB_RELEASE = $(PANDA_ROOTFS)/make-github-release.py
 

--- a/src/hdl/dcard_ctrl.vhd
+++ b/src/hdl/dcard_ctrl.vhd
@@ -30,10 +30,9 @@ port (
     dcard_ctrl3_io      : inout std_logic_vector(15 downto 0);
     dcard_ctrl4_io      : inout std_logic_vector(15 downto 0);
     -- Front Panel Shift Register Interface
-    OUTENC_CONN         : in  std_logic_vector(3 downto 0);
     INENC_PROTOCOL      : in  std3_array(3 downto 0);
     OUTENC_PROTOCOL     : in  std3_array(3 downto 0);
-    DCARD_MODE          : out std4_array(3 downto 0)
+    DCARD_MODE_o        : out std4_array(3 downto 0)
 );
 end dcard_ctrl;
 
@@ -43,15 +42,15 @@ function INENC_CONV (PROTOCOL : std_logic_vector) return std_logic_vector is
 begin
     case (PROTOCOL(2 downto 0)) is
         when "000"  => -- INC
-            return X"03";
+            return X"23";
         when "001"  => -- SSI
             return X"0C";
         when "010"  => -- BiSS-C
-            return X"0C";
+            return X"14";
         when "011"  => -- EnDat
             return X"14";
         when others =>
-            return X"00";
+            return X"20";
     end case;
 end INENC_CONV;
 
@@ -59,83 +58,73 @@ function OUTENC_CONV (PROTOCOL : std_logic_vector) return std_logic_vector is
 begin
     case (PROTOCOL(2 downto 0)) is
         when "000"  => -- INC
-            return X"07";
+            return X"27";
         when "001"  => -- SSI
             return X"28";
         when "010"  => -- BiSS-C
-            return X"28";
+            return X"10";
         when "011"  => -- EnDat
             return X"10";
         when "100"  => -- Pass
-            return X"07";
+            return X"27";
         when "101" => -- Data passthrough (same as SSI)
             return X"28";
         when others =>
-            return X"00";
+            return X"24";
     end case;
 end OUTENC_CONV;
 
-function CONV_PADS(INENC, OUTENC : std_logic_vector) return std_logic_vector is
+function CONV_PADS(INENC, OUTENC, DCARD_MODE : std_logic_vector) return std_logic_vector is
     variable enc_ctrl_pad : std_logic_vector(11 downto 0);
 begin
-
     enc_ctrl_pad(1 downto 0) := INENC(1 downto 0);
-    enc_ctrl_pad(3 downto 2) := OUTENC(1 downto 0);
-    enc_ctrl_pad(4) := INENC(2);
     enc_ctrl_pad(5) := OUTENC(2);
-    enc_ctrl_pad(7 downto 6) := INENC(4 downto 3);
-    enc_ctrl_pad(9 downto 8) := OUTENC(4 downto 3);
-    enc_ctrl_pad(10) := INENC(5);
-    enc_ctrl_pad(11) := OUTENC(5);
+    enc_ctrl_pad(7 downto 6) := INENC(4 downto 3);    
+    if DCARD_MODE(3 downto 1) = DCARD_MONITOR then
+        enc_ctrl_pad(3 downto 2) := "00";
+        enc_ctrl_pad(4) := '0';
+        enc_ctrl_pad(9 downto 8) := "00";
+        enc_ctrl_pad(10) := '1';
+        enc_ctrl_pad(11) := '1';
+    else
+        enc_ctrl_pad(3 downto 2) := OUTENC(1 downto 0);
+        enc_ctrl_pad(4) := INENC(2);
+        enc_ctrl_pad(9 downto 8) := OUTENC(4 downto 3);
+        enc_ctrl_pad(10) := INENC(5);
+        enc_ctrl_pad(11) := OUTENC(5);
+    end if;
 
     return enc_ctrl_pad;
 end CONV_PADS;
 
-signal DCARD_MODE_i     : std4_array(3 downto 0)
-                            := (others => (others => '0'));
-signal inenc_ctrl       : std8_array(3 downto 0);
-signal outenc_ctrl      : std8_array(3 downto 0);
+signal DCARD_MODE   : std4_array(3 downto 0) := (others => (others => '0'));
+signal inenc_ctrl   : std8_array(3 downto 0);
+signal outenc_ctrl  : std8_array(3 downto 0);
 
 begin
+
+DCARD_MODE_o <= DCARD_MODE;
 
 -- DCARD configuration from on-board 0-Ohm settings.
 -- These pins have weak pull-ups on the chip to detect
 -- un-installed daughter cards
-DCARD_MODE_i(0) <= dcard_ctrl1_io(15 downto 12);
-DCARD_MODE_i(1) <= dcard_ctrl2_io(15 downto 12);
-DCARD_MODE_i(2) <= dcard_ctrl3_io(15 downto 12);
-DCARD_MODE_i(3) <= dcard_ctrl4_io(15 downto 12);
+DCARD_MODE(0) <= dcard_ctrl1_io(15 downto 12);
+DCARD_MODE(1) <= dcard_ctrl2_io(15 downto 12);
+DCARD_MODE(2) <= dcard_ctrl3_io(15 downto 12);
+DCARD_MODE(3) <= dcard_ctrl4_io(15 downto 12);
 
--- Assign CTRL values for Input Encoder ICs on the Daughter Card
-INENC_CTRL_GEN : FOR I IN 0 TO 3 GENERATE
+-- Assign CTRL values for Encoder ICs on the Daughter Card
+ENC_CTRL_GEN : FOR I IN 0 TO 3 GENERATE
     inenc_ctrl(I) <= INENC_CONV(INENC_PROTOCOL(I));
+    outenc_ctrl(I) <= OUTENC_CONV(INENC_PROTOCOL(I))
+        when DCARD_MODE(I)(3 downto 1) = DCARD_MONITOR
+        else OUTENC_CONV(OUTENC_PROTOCOL(I));
 END GENERATE;
 
--- Output Encoder Buffer Control depends on Daughter Card Mode, Protocol, and
--- OUTENC_CONN setting.
---
-process(INENC_PROTOCOL, OUTENC_PROTOCOL, DCARD_MODE_i, OUTENC_CONN)
-begin
-    FOR I IN 0 TO 3 LOOP
-        -- Disable all OUTENC buffers. ???
-        if (OUTENC_CONN(I) = '0') then
-            outenc_ctrl(I) <= OUTENC_CONV(OUTENC_PROTOCOL(I));
-        -- Daugther Card in LOOPBACK mode.
-        elsif (DCARD_MODE_i(I)(3 downto 1) = DCARD_MONITOR) then
-            outenc_ctrl(I) <= OUTENC_CONV(INENC_PROTOCOL(I));
-        -- Daughter Card in NORMAL mode.
-        else
-            outenc_ctrl(I) <= OUTENC_CONV(OUTENC_PROTOCOL(I));
-        end if;
-    END LOOP;
-end process;
-
 -- Interleave Input and Output Controls to the Daughter Card Pins.
-dcard_ctrl1_io(11 downto 0) <= CONV_PADS(inenc_ctrl(0), outenc_ctrl(0));
-dcard_ctrl2_io(11 downto 0) <= CONV_PADS(inenc_ctrl(1), outenc_ctrl(1));
-dcard_ctrl3_io(11 downto 0) <= CONV_PADS(inenc_ctrl(2), outenc_ctrl(2));
-dcard_ctrl4_io(11 downto 0) <= CONV_PADS(inenc_ctrl(3), outenc_ctrl(3));
-
-DCARD_MODE <= DCARD_MODE_i;
+dcard_ctrl1_io(11 downto 0) <= CONV_PADS(inenc_ctrl(0), outenc_ctrl(0), DCARD_MODE(0));
+dcard_ctrl2_io(11 downto 0) <= CONV_PADS(inenc_ctrl(1), outenc_ctrl(1), DCARD_MODE(1));
+dcard_ctrl3_io(11 downto 0) <= CONV_PADS(inenc_ctrl(2), outenc_ctrl(2), DCARD_MODE(2));
+dcard_ctrl4_io(11 downto 0) <= CONV_PADS(inenc_ctrl(3), outenc_ctrl(3), DCARD_MODE(3));
 
 end rtl;

--- a/src/hdl/slow_top.vhd
+++ b/src/hdl/slow_top.vhd
@@ -161,10 +161,9 @@ port map (
     dcard_ctrl3_io      => dcard_ctrl3_io,
     dcard_ctrl4_io      => dcard_ctrl4_io,
     -- Front Panel Shift Register Interface
-    OUTENC_CONN         => OUTENC_CONN,
     INENC_PROTOCOL      => INENC_PROTOCOL,
     OUTENC_PROTOCOL     => OUTENC_PROTOCOL,
-    DCARD_MODE          => DCARD_MODE
+    DCARD_MODE_o        => DCARD_MODE
 );
 
 --

--- a/src/hdl/zynq_interface.vhd
+++ b/src/hdl/zynq_interface.vhd
@@ -62,10 +62,11 @@ begin
     return X"00" &  "00000" & outenc & "00000" & inenc & X"0" & mode;
 end dcard_pack;
 
--- There are 32 status registers allocated for slow controller
-signal STATUS_LIST          : std32_array(31 downto 0) :=
+constant NUM_REGS           : natural := 18;
+
+signal STATUS_LIST          : std32_array(NUM_REGS-1 downto 0) :=
                                         (others => (others => '0'));
-signal register_index       : natural range 0 to 31;
+signal register_index       : natural range 0 to STATUS_LIST'HIGH;
 
 signal wr_req               : std_logic;
 signal wr_dat               : std_logic_vector(31 downto 0);
@@ -193,7 +194,7 @@ process(clk_i) begin
                 wr_adr <= TO_SVECTOR(register_index, 10);
                 wr_dat <= STATUS_LIST(register_index);
                 -- Keep track of registers
-                if (register_index = 31) then
+                if (register_index = NUM_REGS-1) then
                     register_index <= 0;
                 else
                     register_index <= register_index + 1;


### PR DESCRIPTION
Tidy up of daughter card configuration for the encoders.
Slow FPGA is responsible for reading the DCARD_TYPE and setting appropriate transceiver enable signals and termination settings, which take priority over the protocol settings as sent from the Zynq.

See commit messages for more details.